### PR TITLE
Add TransportException-specific handling

### DIFF
--- a/SyncOrg/src/main/java/com/coste/syncorg/synchronizers/JGitWrapper.java
+++ b/SyncOrg/src/main/java/com/coste/syncorg/synchronizers/JGitWrapper.java
@@ -347,6 +347,8 @@ public class JGitWrapper {
             }else if(exception instanceof UnableToPushException) {
                 //				git config receive.denyCurrentBranch ignore
                 Toast.makeText(context, "Push test failed. Make sure the repository is bare.", Toast.LENGTH_LONG).show();
+            }else if(exception instanceof TransportException) {
+                Toast.makeText(context, context.getString(R.string.error_transport_error), Toast.LENGTH_LONG).show();
             }else{
                 Toast.makeText(context, exception.toString(), Toast.LENGTH_LONG).show();
                 ((Exception)exception).printStackTrace();

--- a/SyncOrg/src/main/res/values-de/strings.xml
+++ b/SyncOrg/src/main/res/values-de/strings.xml
@@ -45,6 +45,7 @@
 
   <string name="preference_autosync">Synchronisierung im Hintergrund</string>
 
+  <string name="error_transport_error">Git-Fehler. Dieser Fehler kommt normalerweise vor, wenn es ein Problem mit der Repository gibt. Ist der Pfad zur Repository richtig? Ist git auf dem Server installiert?</string>
   <string name="error_sqlio">Problem beim Lesen der Datenbank. Ist das Medium fehlerhaft oder die SD-Karte nicht verfügbar?</string>
   <string name="error_generic_database">Allgemeiner Datenbankfehler: %s</string>
   <string name="error_file_not_found">Die Datei %s wurde nicht gefunden</string>

--- a/SyncOrg/src/main/res/values/strings.xml
+++ b/SyncOrg/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="error_dialog_title">Error</string>
     <string name="error_apg_not_found">APG not found</string>
     <string name="error_apg_version_not_supported">APG version not supported</string>
+    <string name="error_transport_error">Git error. This usually happens when there was a problem with the repository. Is the path correct? Is git installed on the server?</string>
 
     <!-- menu strings -->
     <string name="menu_outline">Outline</string>


### PR DESCRIPTION
Patch discussed here [https://github.com/wizmer/syncorg/issues/7](url). I looked at the sources for jgit and it looks like `TransportExceptions` mostly get thrown when there is something keeping git from working properly (or when git is missing all together :) Based on this, I chose the wording in `strings.xml`. I also added the German counterpart. I'm not a native speaker, but I've been living here for 7 years, so it should be mostly correct.
