### PR TITLE
Don't commit when no files have changed

### DIFF
--- a/SyncOrg/src/main/java/com/coste/syncorg/synchronizers/JGitWrapper.java
+++ b/SyncOrg/src/main/java/com/coste/syncorg/synchronizers/JGitWrapper.java
@@ -430,6 +430,9 @@ public class JGitWrapper {
             Git git = null;
             try {
                 git = Git.open(repoDir);
+                if (git.status().call().isClean()) {
+                    return null;
+                }
                 // Stage all changed files, omitting new files, and commit with one command
 
 //                org.eclipse.jgit.api.Status status = git.status().call();


### PR DESCRIPTION
This change stops empty commits being made as highlighted in https://github.com/wizmer/syncorg/issues/16

Maybe the issue could be looked into more so that synchronizing isn't attempted unless nodes have been modified or files changed.