### PR TITLE
Fixed timestamp import off by one for month field.

### DIFF
--- a/SyncOrg/src/main/java/com/coste/syncorg/orgdata/OrgNodeTimeDate.java
+++ b/SyncOrg/src/main/java/com/coste/syncorg/orgdata/OrgNodeTimeDate.java
@@ -194,7 +194,7 @@ public class OrgNodeTimeDate {
             matchEnd = propm.end();
             try {
                 year = Integer.parseInt(propm.group(2));
-                monthOfYear = Integer.parseInt(propm.group(3));
+                monthOfYear = Integer.parseInt(propm.group(3)) - 1; //java date months are off by one
                 dayOfMonth = Integer.parseInt(propm.group(4));
 
                 if (propm.group(6) != null && propm.group(7) != null) {

--- a/SyncOrg/src/test/java/SimpleTests.java
+++ b/SyncOrg/src/test/java/SimpleTests.java
@@ -9,18 +9,18 @@ import org.mockito.junit.MockitoRule;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 
-public class MockitoTest {
+public class SimpleTests {
 
-    @Rule
-    public MockitoRule mockitoRule = MockitoJUnit.rule();
-    @Mock
-    Context context;
-
-    @Test
-    public void testQuery() {
-        ClassToTest t = new ClassToTest(databaseMock);
-        boolean check = t.query("* from t");
-        assertTrue(check);
-        verify(databaseMock).query("* from t");
-    }
+//    @Rule
+//    public MockitoRule mockitoRule = MockitoJUnit.rule();
+//    @Mock
+//    Context context;
+//
+//    @Test
+//    public void testQuery() {
+//        ClassToTest t = new ClassToTest(databaseMock);
+//        boolean check = t.query("* from t");
+//        assertTrue(check);
+//        verify(databaseMock).query("* from t");
+//    }
 }

--- a/SyncOrg/src/test/java/com/coste/syncorg/orgdata/OrgNodeTimeDateTest.java
+++ b/SyncOrg/src/test/java/com/coste/syncorg/orgdata/OrgNodeTimeDateTest.java
@@ -1,0 +1,42 @@
+package com.coste.syncorg.orgdata;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class OrgNodeTimeDateTest {
+
+    @Test
+    public void thatAScheduledDateWithWeekdayIsParsed() throws Exception {
+        String line = "  SCHEDULED: <2017-03-15 Wed>";
+        OrgNodeTimeDate orgNodeTimeDate = new OrgNodeTimeDate(OrgNodeTimeDate.TYPE.Scheduled, line);
+        assertEquals(2017, orgNodeTimeDate.year);
+        assertEquals(2, orgNodeTimeDate.monthOfYear);
+        assertEquals(15, orgNodeTimeDate.dayOfMonth);
+        assertEquals(OrgNodeTimeDate.TYPE.Scheduled ,orgNodeTimeDate.type);
+    }
+
+    @Test
+    public void thatADeadlineDateWithWeekdayIsParsed() throws Exception {
+        String line = "  DEADLINE: <2017-01-15 Wed>";
+        OrgNodeTimeDate orgNodeTimeDate = new OrgNodeTimeDate(OrgNodeTimeDate.TYPE.Deadline, line);
+        assertEquals(2017, orgNodeTimeDate.year);
+        assertEquals(0, orgNodeTimeDate.monthOfYear);
+        assertEquals(15, orgNodeTimeDate.dayOfMonth);
+    }
+
+    @Test
+    public void thatADeadlineAndScheduledDateWithAndWithoutWeekdayAreParsed() throws Exception {
+        String line = "  DEADLINE: <2017-04-03 Mon> SCHEDULED: <2017-03-30>";
+        OrgNodeTimeDate orgNodeTimeDate = new OrgNodeTimeDate(OrgNodeTimeDate.TYPE.Scheduled, line);
+        assertEquals(2017, orgNodeTimeDate.year);
+        assertEquals(2, orgNodeTimeDate.monthOfYear);
+        assertEquals(30, orgNodeTimeDate.dayOfMonth);
+
+        orgNodeTimeDate = new OrgNodeTimeDate(OrgNodeTimeDate.TYPE.Deadline, line);
+        assertEquals(2017, orgNodeTimeDate.year);
+        assertEquals(3, orgNodeTimeDate.monthOfYear);
+        assertEquals(3, orgNodeTimeDate.dayOfMonth);
+    }
+}


### PR DESCRIPTION
IDK whether I am the only one experiencing this problem, but whenever I import scheduled items from my desktop, the seem to be off by one month. I wrote a test that shows the issue for me and changed the import to add one to the month field.